### PR TITLE
Add support for raw query to fix issue with query imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "influxrs"
 description = "Provides a client for writing and reading data from InfluxDB 2.0"
-version = "2.0.1"
+version = "2.1.0"
 authors = ["Isak Jägberg <ijagberg@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/client.rs
+++ b/src/client.rs
@@ -58,9 +58,12 @@ impl InfluxClient {
 
     pub async fn query(&self, query: Query) -> Result<InfluxQueryResponse, InfluxError> {
         let payload = query.to_string();
+        self.raw_query(&payload).await
+    }
 
+    pub async fn raw_query(&self, query: &str) -> Result<InfluxQueryResponse, InfluxError> {
         let url = format!("{}/api/v2/query?org={}", self.url, self.org);
-        trace!("posting query to influx at '{}': '{}'", url, payload);
+        trace!("posting query to influx at '{}': '{}'", url, query);
 
         let request = isahc::Request::builder()
             .uri(&url)
@@ -68,7 +71,7 @@ impl InfluxClient {
             .header("Authorization", format!("Token {}", &self.key))
             .header("Content-Type", "application/vnd.flux")
             .header("Accept", "application/csv")
-            .body(payload)?;
+            .body(query)?;
 
         let mut response = self.http_client.send_async(request).await?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,6 +4,7 @@ use std::{collections::HashMap, error::Error, fmt::Display};
 
 pub type InfluxQueryResponse = Vec<HashMap<String, String>>;
 
+#[derive(Clone)]
 pub struct InfluxClient {
     url: String,
     key: String,
@@ -106,6 +107,7 @@ impl InfluxClient {
     }
 }
 
+#[derive(Clone)]
 pub struct InfluxClientBuilder {
     url: String,
     key: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ impl Measurement {
     fn fields_part(&self) -> String {
         self.fields
             .iter()
-            .map(|(name, value)| format!("{}={}", name, value.to_string()))
+            .map(|(name, value)| format!("{}={}", name.replace(" ", "\\ "), value.to_string()))
             .collect::<Vec<_>>()
             .join(",")
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ impl Display for Field {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Field::Float(v) => write!(f, "{}", v),
+            Field::String(v) if v.contains("\\") || v.contains("\"") => write!(f, r#""{}""#, v.replace("\\", "\\\\").replace("\"", "\\\"")),
             Field::String(v) => write!(f, r#""{}""#, v),
             Field::Bool(v) => write!(f, "{}", v),
             Field::Integer(v) => write!(f, "{}i", v),

--- a/src/query.rs
+++ b/src/query.rs
@@ -25,10 +25,7 @@ impl Query {
         let lines = query
             .into()
             .lines()
-            .map(|l| match l.strip_prefix("|>") {
-                Some(stripped) => stripped.trim().to_owned(),
-                None => l.trim().to_owned(),
-            })
+            .map(|l| l.trim().to_owned())
             .collect();
         Self { lines }
     }
@@ -42,7 +39,7 @@ impl Query {
     ///     .then(r#"filter(fn: (r) => r["_measurement"] == "example_measurement")"#);
     /// ```
     pub fn then(mut self, line: impl Into<String>) -> Self {
-        self.lines.push(line.into());
+        self.lines.push(format!(" |> {}", line.into()));
         self
     }
 }
@@ -56,7 +53,7 @@ impl Display for Query {
                 .iter()
                 .map(|l| l.to_string())
                 .collect::<Vec<_>>()
-                .join("\n |> ")
+                .join("\n")
         )
     }
 }


### PR DESCRIPTION
This is to fix an issue w/ running queries that include imports, ex:

```
  import "timezone"
  import "types"

option location = timezone.location(name: "America/Chicago")

from(bucket: "beacon")
  |> range(start: -1h)
  |> filter(fn: (r) => r["device"] == "10" )
  |> filter(fn: (r) => types.isNumeric(v: r._value))
  |> aggregateWindow( every: 15m, fn: last, timeSrc: "_start")
  |> max()
```
The change to Query::raw is technically breaking- a query of the form `from(bucket: "") \n range(start: -1h) \n ...` would have worked previously, but will now cause a server error of some sort.

I also added a raw_query interface to the client, since it didn't seem reasonable to have so many round trips through iterators, formats, and collects if the query was already well formed / didn't need dynamic construction.