### PR TITLE
escape tag values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,10 @@ struct TagValue(String);
 
 impl TagValue {
     fn new(s: String) -> Self {
-        let s = s.replace(' ', "\\ ");
+        let s = s
+            .replace(',', "\\,")
+            .replace('=', "\\=")
+            .replace(' ', "\\ ");
         Self(s)
     }
 }
@@ -353,6 +356,21 @@ mod tests {
                 .collect(),
                 timestamp_ms: 1602321877560
             }
+        );
+    }
+
+    #[test]
+    fn measurement_escaping() {
+        let m = Measurement::builder("example_measurement")
+            .tag("agent", "KHTML, like Gecko")
+            .field("count", 1.0)
+            .timestamp_ms(1602321877560)
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            m.to_line_protocol(),
+            r#"example_measurement,agent=KHTML\,\ like\ Gecko count=1 1602321877560"#,
         );
     }
 }


### PR DESCRIPTION
This is the minimal fix for #4 

The spec also talks about escaping a bunch of other things, like measurement names, keys and field values. If you want to, I can follow up with a fix for those when I'm done with my current cargo-quickinstall PR.