### PR TITLE
fix: Support static builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ isahc = "1.4.0"
 tokio = { version = "1.3.0", features = ["full"] }
 dotenv = "0.15.0"
 pretty_env_logger = "0.4.0"
+
+[features]
+static = ["isahc/static-ssl", "isahc/static-curl"]


### PR DESCRIPTION
When trying to use `cargo-zigbuild` for `--target x86_64-unknown-linux-musl` from a glibc build host, it was not possible to make a static binary due to the `isahc` dependency only enabling `static-curl` by default.

Add a `static` feature to enable the [`isahc/static-ssl` feature](https://github.com/sagebind/isahc/blob/9d1edd475231ad5cfd5842d939db1382dc3a88f5/Cargo.toml#L30C1-L30C11) in addition to the default feature `isahc/static-curl`.

Not sure why, but it seems that static openssl also makes zlib static 🤔 