### PR TITLE
Fix precision query parameter

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -38,7 +38,7 @@ impl InfluxClient {
             .collect::<Vec<_>>()
             .join("\n");
         let url = format!(
-            "{}/api/v2/write?org={}&bucket={}&precision=ms",
+            "{}/api/v2/write?org={}&bucket={}&precision=ns",
             self.url, self.org, bucket
         );
 


### PR DESCRIPTION
Changed `precision` query parameter of URI used when writing to InfluxDB from `ms` to `ns` to reflect the changed precision of measurement timestamps.

This fixes #7